### PR TITLE
fix: uninstall apt & snap before version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+2.0.1
+-----
+
+### Fixed
+
+- version checking before apt and snap packages uninstallation led to skip compile when the same version is installed
+  via snap or apt.
+
 2.0.0
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Changelog
 - version checking before apt and snap packages uninstallation led to skip compile when the same version is installed
   via snap or apt.
 
+### Changed
+
+- print the state of startup flag.
+
 2.0.0
 -----
 

--- a/tasks/compile.yml
+++ b/tasks/compile.yml
@@ -5,22 +5,6 @@
     name: "{{ __flameshot_compilation_dependencies }}"
     state: "present"
 
-- name: "Remove apt package {{ __flameshot_package }}."
-  apt:
-    name: "{{ __flameshot_package }}"
-    state: "absent"
-
-- name: "Gather installed packages in search for Snap."
-  package_facts:
-    manager: apt
-
-- name: "Remove snap package {{ __flameshot_package }}."
-  snap:
-    name: "{{ __flameshot_package }}"
-    state: "absent"
-  when: >
-    'snapd' in ansible_facts.packages
-
 - name: "Ensure git source repo clone will be OK."
   file:
     path: "{{ __flameshot_source_dir }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,9 @@
 
 - block:
 
+    - name: "Remove installed apt and snap {{ __flameshot_package }} packages before checking the installed version."
+      include_tasks: remove_apt_and_snap_installations.yml
+
     - include_tasks: check_installed_version.yml
 
     - include_tasks: version_expansion.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,6 +38,7 @@
 
   when: flameshot_compile
 
-- name: "Enable or disable run at startup"
+- name: "Set run at startup to {{ flameshot_enable_autostart }}"
   command: flameshot config --autostart "{{ flameshot_enable_autostart }}"
-  changed_when: false
+  register: flameshot_config_autostart
+  changed_when: "flameshot_config_autostart.rc != 0"

--- a/tasks/remove_apt_and_snap_installations.yml
+++ b/tasks/remove_apt_and_snap_installations.yml
@@ -1,0 +1,17 @@
+---
+
+- name: "Remove apt package {{ __flameshot_package }} or it will break version checking."
+  apt:
+    name: "{{ __flameshot_package }}"
+    state: "absent"
+
+- name: "Gather installed apt packages in search for Snap."
+  package_facts:
+    manager: apt
+
+- name: "Remove snap package {{ __flameshot_package }} or it will break version checking."
+  snap:
+    name: "{{ __flameshot_package }}"
+    state: "absent"
+  when: >
+    'snapd' in ansible_facts.packages


### PR DESCRIPTION
Fixed

- version checking before apt and snap packages uninstallation led to
  skip compile when the same version is installed
  via snap or apt.