### PR TITLE
fix: unstable version & reinstallation every run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+2.0.2
+-----
+
+### Fixed:
+    
+- latest stable release version could be release-candidate like `v11.0.rc1` due to poor tag filtering;
+- installed version check was broken since v11.0.0 `flameshot --version` output goes to stderr, not stdout.
+
 2.0.1
 -----
 

--- a/tasks/check_installed_version.yml
+++ b/tasks/check_installed_version.yml
@@ -11,9 +11,9 @@
 
     - name: "Get installed version."
       shell: >
-        flameshot --version 2>&1 
-        | grep -i "flameshot" 
-        | grep -o -P "v\d+.\d+.\d+"
+       flameshot --version 2>&1
+       | grep -i "flameshot"
+       | grep -o -P "v\d+.\d+.\d+"
       register: flameshot_installed_version
       changed_when: false
 

--- a/tasks/check_installed_version.yml
+++ b/tasks/check_installed_version.yml
@@ -10,7 +10,10 @@
   block:
 
     - name: "Get installed version."
-      shell: flameshot --version | grep -i "flameshot" | grep -o -P "v\d+.\d+.\d+"
+      shell: >
+        flameshot --version 2>&1 
+        | grep -i "flameshot" 
+        | grep -o -P "v\d+.\d+.\d+"
       register: flameshot_installed_version
       changed_when: false
 

--- a/tasks/version_expansion.yml
+++ b/tasks/version_expansion.yml
@@ -13,7 +13,10 @@
   changed_when: false
 
 - name: "Find latest stable release version."
-  shell: git -C "{{ __flameshot_source_dir }}" tag --list "v*" --sort "-v:refname" | head -n 1
+  shell: >
+    git -C "{{ __flameshot_source_dir }}" tag --list "v*" --sort "-v:refname"
+    | grep -P "^v\d+\.\d+\.\d+$"
+    | head -n 1
   register: latest_stable
   # just for ansible-lint
   changed_when: false


### PR DESCRIPTION
Fixed:

- latest stable release version could be release-candidate like
  "v11.0.rc1" due to poor tag filtering;
- installed version check was broken since v11.0.0 "flameshot --version"
  output goes to stderr, not stdout.